### PR TITLE
fix for showing Apply Filters btn on resets

### DIFF
--- a/src/app/applications/phm/default/populationselect/popslicer/popslicer.component.ts
+++ b/src/app/applications/phm/default/populationselect/popslicer/popslicer.component.ts
@@ -582,6 +582,8 @@ export class PopslicerComponent implements OnInit {
                     this.neighbourhoodSelect.redraw();
                     this.loadFilters = {};
                     this.loading = false;
+                    this.showAgeFilterBtn = false;
+                    this.showRiskFilterBtn = false;
                 }
             });
         }
@@ -618,6 +620,8 @@ export class PopslicerComponent implements OnInit {
             this.resetBtnPushed = false;
             this.loadFilters = {};
             this.loading = false;
+            this.showAgeFilterBtn = false;
+            this.showRiskFilterBtn = false;
             setTimeout(() => {
                 if (this.selectedPopulation !== this.totalsize) {
                     this.resetToWholePop();


### PR DESCRIPTION
The new apply filter buttons for Age and Risk chart are displaying when the reset buttons are selected on other graphs or the main reset button is clicked. This fix should ensure that the apply filter buttons only show when required